### PR TITLE
Adding center option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scad-js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Generate OpenSCAD solid models with javascript",
   "main": "./src/index.js",
   "repository": {

--- a/src/objects.js
+++ b/src/objects.js
@@ -14,9 +14,10 @@ module.exports = {
     r,
     ...params,
   }),
-  square: (size = [1, 1]) => object('square')({
+  square: (size = [1, 1], params = {}) => object('square')({
     size,
     center,
+    ...params,
   }),
   polygon: (points = undef, paths = undef, convexity = 1) => object('polygon')({
     points,
@@ -27,9 +28,10 @@ module.exports = {
     r,
     ...params,
   }),
-  cube: (size = [1, 1, 1]) => object('cube')({
+  cube: (size = [1, 1, 1], params = {}) => object('cube')({
     size,
     center,
+    ...params,
   }),
   cylinder: (h = 1, r = 1, params = {}) => object('cylinder')({
     h,

--- a/test/objects.js
+++ b/test/objects.js
@@ -48,6 +48,12 @@ describe('Square', () => {
       { type: 'square', params: { size: [8, 3], center: true } },
     );
   });
+  it('should create a square with defined size and not centered', () => {
+    assert.deepEqual(
+      S.square(8, { center: false }),
+      { type: 'square', params: { size: 8, center: false } },
+    );
+  });
 });
 
 describe('Polygon', () => {
@@ -131,6 +137,12 @@ describe('Cube', () => {
       { type: 'cube', params: { size: [4, 5, 6], center: true } },
     );
   });
+  it('should create a cube with defined size not centered', () => {
+    assert.deepEqual(
+      S.cube(4, { center: false }), 
+      { type: 'cube', params: { size: 4, center: false } },
+    );
+  });
 });
 
 describe('Cylinder', () => {
@@ -160,6 +172,12 @@ describe('Cylinder', () => {
     assert.deepEqual(
       S.cylinder(5, [3, 5], { $fa: 0, $fn: 0, $fs: 0 }),
       { type: 'cylinder', params: { h: 5, r1: 3, r2: 5, center: true, $fa: 0, $fn: 0, $fs: 0   } },
+    );
+  });
+  it('should create a cylinder with defined size and not centered', () => {
+    assert.deepEqual(
+      S.cylinder(5, 4, { center: false }),
+      { type: 'cylinder', params: { h: 5, r: 4, center: false } },
     );
   });
 });


### PR DESCRIPTION
Square, cube, and cylinder was centered by default. added option to disable center on those objects. 